### PR TITLE
Added Github and my personal server to Computer Craft HTTP API whitelist

### DIFF
--- a/config/ComputerCraft.cfg
+++ b/config/ComputerCraft.cfg
@@ -47,7 +47,7 @@ general {
     B:http_enable=true
 
     # A semicolon limited list of wildcards for domains that can be accessed through the "http" API on Computers. Set this to "*" to access to the entire internet.
-    S:http_whitelist=*pastebin.com;*computercraft.info
+    S:http_whitelist=*pastebin.com;*computercraft.info;*github.com;*mort.is
 
     # The range of Wireless Modems at maximum altitude in clear weather, in meters
     I:modem_highAltitudeRange=384


### PR DESCRIPTION
Added github.com and mort.is to Computer Craft HTTP API whitelist so people can download files from Github and so I can use my personal server to download files (I have a fancy self-update thing going that will update my scripts from a git repo on my server). 
