### PR TITLE
Changed reload-dimensions to true for ChickenChunks.

### DIFF
--- a/ChickenChunks.cfg
+++ b/ChickenChunks.cfg
@@ -40,4 +40,4 @@ maxchunks=49
 op-interact=false
 
 #Set to false to disable the automatic reloading of mystcraft dimensions on server restart
-reload-dimensions=false
+reload-dimensions=true


### PR DESCRIPTION
Changed reload-dimensions to true for ChickenChunks to try to get Mystcraft and RFTools dimensions to load on server start
